### PR TITLE
Fix typo

### DIFF
--- a/manual/configuration_ja.html
+++ b/manual/configuration_ja.html
@@ -648,7 +648,7 @@ import ch.qos.logback.classic.LoggerContext;
   <p><code>layout要素</code>にはclass属性が必須です。レイアウトクラスの完全名を指定します。<code>appender要素</code>と同じく、<code>layout要素</code>にはレイアウトクラスのプロパティを含めることができます。レイアウトクラスとして<code>PatternLayout</code>を指定するのが一般的なので、その場合class属性は省略できるようになっています。これは<a href="./onJoran_ja.html#defaultClassMapping">デフォルトのクラスマッピングルール</a>で定義されています。
   </p>
 
-  <p><code>encoder要素</code>にはclass属性が必須です。エンコーダクラスの完全名を指定します。エンコーダクラスとして<code>PaternLayoutEncoder</code>を指定するのが一般的なので、その場合class属性を省略できるようになっています。これは<a href="./onJoran_ja.html#defaultClassMapping">デフォルトのクラスマッピングルール</a>で定義されています。
+  <p><code>encoder要素</code>にはclass属性が必須です。エンコーダクラスの完全名を指定します。エンコーダクラスとして<code>PatternLayoutEncoder</code>を指定するのが一般的なので、その場合class属性を省略できるようになっています。これは<a href="./onJoran_ja.html#defaultClassMapping">デフォルトのクラスマッピングルール</a>で定義されています。
   </p>
 
   <p>複数のアペンダーにログを出力するのも、さまざまなアペンダーを定義してロガーから参照するのも簡単です。設定ファイルの例を示しましょう。</p>


### PR DESCRIPTION
Fixed minor typos.
No functional changes. This is a non-breaking update to improve readability and clarity.